### PR TITLE
set title of browser tab from metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _build
 */.ipynb_checkpoints/*
 .tox
 .nox
+.idea/

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,5 +1,13 @@
 {%- extends "pydata_sphinx_theme/layout.html" %}
 
+{%- block htmltitle %}
+
+{%- if meta is mapping and "title" in meta %}
+<title>{{ meta.get("title")|striptags|e }}{{ titlesuffix }}</title>
+{%- endif %}
+
+{%- endblock %}
+
 {% block docs_body %}
 
 {%- if meta is mapping and "title" in meta %}


### PR DESCRIPTION
The title of the pages are not rendering correctly. For example, for the page **Senior Engineers** the title is **Are technically skilled** (which is the title of the first section)

This commit fixes this problem by fetching the title from the metadata.